### PR TITLE
Refactor debounce options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ spec_shared: &spec_shared
 jobs:
   deps:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.7
     working_directory: ~/sidekiq_fast_debounce
 
     steps:
@@ -47,7 +47,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
+            - v2-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
 
       - run:
           name: install dependencies
@@ -57,7 +57,7 @@ jobs:
       - save_cache:
           paths:
             - vendor/bundle
-          key: v1-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
+          key: v2-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
 
       - run:
           name: dependencies security audit
@@ -67,6 +67,11 @@ jobs:
       - run:
           name: Rubocop
           command: bundle exec rubocop
+
+  ruby-2.7:
+    <<: *spec_shared
+    docker:
+      - image: circleci/ruby:2.7
 
   ruby-2.6:
     <<: *spec_shared
@@ -90,7 +95,7 @@ jobs:
 
   generate_docs:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.7
     working_directory: ~/sidekiq_fast_debounce
 
     steps:
@@ -125,6 +130,9 @@ workflows:
   build:
     jobs:
       - deps
+      - ruby-2.7:
+          requires:
+            - deps
       - ruby-2.6:
           requires:
             - deps
@@ -139,6 +147,7 @@ workflows:
             - deps
       - generate_docs:
           requires:
+            - ruby-2.7
             - ruby-2.6
             - ruby-2.5
             - ruby-2.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,6 @@ jobs:
     docker:
       - image: circleci/ruby:2.5
 
-  ruby-2.4:
-    <<: *spec_shared
-    docker:
-      - image: circleci/ruby:2.4
-
-  ruby-2.3:
-    <<: *spec_shared
-    docker:
-      - image: circleci/ruby:2.3
-
   generate_docs:
     docker:
       - image: circleci/ruby:2.7
@@ -103,7 +93,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
+            - v2-dependencies-{{ checksum "sidekiq_fast_debounce.gemspec" }}
 
       - run:
           name: Setup bundler path
@@ -139,16 +129,8 @@ workflows:
       - ruby-2.5:
           requires:
             - deps
-      - ruby-2.4:
-          requires:
-            - deps
-      - ruby-2.3:
-          requires:
-            - deps
       - generate_docs:
           requires:
             - ruby-2.7
             - ruby-2.6
             - ruby-2.5
-            - ruby-2.4
-            - ruby-2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* All enqueue time customizations are set via `set()` instead of as optional parameters named-(ish) to the method.
+
 ## 0.1.0
 
 * Initial Release

--- a/lib/sidekiq_fast_debounce.rb
+++ b/lib/sidekiq_fast_debounce.rb
@@ -83,8 +83,10 @@ module SidekiqFastDebounce
   end
 
   # Add perform_debounce to Sidekiq::Worker::Setter to enable set(..).perform_debounce(...)
+  # @see https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/worker.rb
   module Setter
     def perform_debounce(delay, *args)
+      # @klass and @opts are an instance variables on Sidekiq::Worker::Setter
       item = {
         'class' => @klass,
         'args' => args,

--- a/lib/sidekiq_fast_debounce.rb
+++ b/lib/sidekiq_fast_debounce.rb
@@ -82,6 +82,7 @@ module SidekiqFastDebounce
     end
   end
 
+  # Add perform_debounce to Sidekiq::Worker::Setter to enable set(..).perform_debounce(...)
   module Setter
     def perform_debounce(delay, *args)
       item = {

--- a/lib/sidekiq_fast_debounce/middleware/client.rb
+++ b/lib/sidekiq_fast_debounce/middleware/client.rb
@@ -7,7 +7,7 @@ require_relative '../utils'
 module Middleware
   module Sidekiq
     module Client
-      # Sidekiq client middle to handle setting the debounce key for a debounced job
+      # Sidekiq client middleware to handle setting the debounce key for a debounced job
       class FastDebounce
         # @param [String, Class] worker_class the string or class of the worker class being enqueued
         # @param [Hash] job the full job payload

--- a/lib/sidekiq_fast_debounce/middleware/client.rb
+++ b/lib/sidekiq_fast_debounce/middleware/client.rb
@@ -32,7 +32,7 @@ module Middleware
             expires_in = delay + ttl.to_i
 
             ::Sidekiq.redis do |conn|
-              conn.setex(job['debounce_key'], expires_in, jid)
+              conn.setex(job['debounce_key'], expires_in.to_i, jid)
             end
           end
 

--- a/lib/sidekiq_fast_debounce/utils.rb
+++ b/lib/sidekiq_fast_debounce/utils.rb
@@ -19,7 +19,7 @@ module SidekiqFastDebounce
       # @return [String] key to use for this job
       def base_key(job)
         key = job[:debounce_key] || job['debounce_key']
-        return key unless key.nil?
+        return key if key
 
         if job['args'].empty?
           'DEBOUNCE_NO_ARGS'

--- a/lib/sidekiq_fast_debounce/utils.rb
+++ b/lib/sidekiq_fast_debounce/utils.rb
@@ -8,11 +8,26 @@ module SidekiqFastDebounce
       # @param job [Hash] hash that represents a Sidekiq job
       # @return [String] key to use for this job
       def debounce_key(job)
-        raise ArgumentError, 'No way to determine debounce key' if job['args'].empty?
+        namespace = job[:debounce_namespace] || job['debounce_namespace']
+        namespace ||= job['class'].to_s
 
-        return job['args'].first if job['args'].length == 1
+        "debounce::#{namespace}::#{base_key(job)}"
+      end
 
-        Digest::MD5.hexdigest(job['args'].to_json)
+      # Get the options for debounced Sidekiq job
+      # @param job [Hash] hash that represents a Sidekiq job
+      # @return [String] key to use for this job
+      def base_key(job)
+        key = job[:debounce_key] || job['debounce_key']
+        return key unless key.nil?
+
+        if job['args'].empty?
+          'DEBOUNCE_NO_ARGS'
+        elsif job['args'].length == 1
+          job['args'].first
+        else
+          Digest::MD5.hexdigest(job['args'].to_json)
+        end
       end
     end
   end

--- a/lib/sidekiq_fast_debounce/utils.rb
+++ b/lib/sidekiq_fast_debounce/utils.rb
@@ -4,101 +4,15 @@ module SidekiqFastDebounce
   # Utility methods for dealing with debounce options
   class Utils
     class << self
-      # Turn a string into a class
-      # @param klass [String, Class]
-      # @return [Class]
-      def const(klass)
-        if klass.is_a?(Class)
-          klass
-        elsif klass.is_a?(String)
-          klass.split('::').reduce(Module, :const_get)
-        else
-          raise ArgumentError, "klass should be String or Class, it is `#{klass.class}`"
-        end
-      end
-
-      # Extract the give key, with indifferent access, from args. Deletes it from args.
-      # @param key [Symbol] key to extract
-      # @param args [Hash] last arg from Sidekiq, if
-      # @return [Hash]
-      def extract_opt!(key, args)
-        opt = {}
-
-        key_s = key.to_s
-        key_sym = key.to_sym
-
-        if args.key?(key_s)
-          opt[:value] = args.delete(key_s)
-        elsif args.key?(key_sym)
-          opt[:value] = args.delete(key_sym)
-        end
-
-        opt
-      end
-
       # Get the options for debounced Sidekiq job
       # @param job [Hash] hash that represents a Sidekiq job
-      # @return [Hash] debounce specific options
-      def debounce_opts(job)
-        args = job['args']
-        num_args = args.length
-
-        opts = {}
-
-        if args.last.is_a?(Hash)
-          arg_opts = args.last
-
-          found_debounce_opt = false
-
-          key_opts = extract_opt!(:debounce_key, arg_opts)
-          if key_opts.key?(:value)
-            found_debounce_opt = true
-            opts[:debounce_key] = key_opts[:value]
-          end
-
-          namespace_opts = extract_opt!(:debounce_namespace, arg_opts)
-          if namespace_opts.key?(:value)
-            found_debounce_opt = true
-            opts[:debounce_namespace] = namespace_opts[:value]
-          end
-
-          if found_debounce_opt
-            if arg_opts.empty?
-              args.pop
-            else
-              args[num_args - 1] = arg_opts
-            end
-          end
-        end
-
-        opts
-      end
-
-      # Get the options for debounced Sidekiq job
-      # @param klass [Class] Sidekiq worker class
-      # @param job [Hash] hash that represents a Sidekiq job
-      # @param deb_opts [Hash] debounce specific options
-      # @return [String] namespace to use for this job's debounce key
-      def debounce_namespace(klass, _job, deb_opts = {})
-        return deb_opts[:debounce_namespace] if deb_opts.key?(:debounce_namespace)
-
-        klass.to_s
-      end
-
-      # Get the options for debounced Sidekiq job
-      # @param klass [Class] Sidekiq worker class
-      # @param job [Hash] hash that represents a Sidekiq job
-      # @param deb_opts [Hash] debounce specific options
       # @return [String] key to use for this job
-      def debounce_key(_klass, job, deb_opts = {})
-        return deb_opts[:debounce_key] if deb_opts.key?(:debounce_key)
+      def debounce_key(job)
         raise ArgumentError, 'No way to determine debounce key' if job['args'].empty?
 
-        if job['args'].length == 1
-          job['args'].first
-        else
-          Digest::MD5.hexdigest(job['args'].to_json)
-        end
+        return job['args'].first if job['args'].length == 1
+
+        Digest::MD5.hexdigest(job['args'].to_json)
       end
     end
   end

--- a/sidekiq_fast_debounce.gemspec
+++ b/sidekiq_fast_debounce.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'fakeredis'
   spec.add_development_dependency 'rake'

--- a/sidekiq_fast_debounce.gemspec
+++ b/sidekiq_fast_debounce.gemspec
@@ -47,4 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
   spec.add_development_dependency 'rubocop', '0.65.0'
   spec.add_development_dependency 'yard'
+
+  # psych 4 breaks some existing YAML loading code in bundler-audit
+  spec.add_development_dependency 'psych', '< 4'
 end

--- a/spec/client_middleware_spec.rb
+++ b/spec/client_middleware_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Middleware::Sidekiq::Client::FastDebounce do
   describe 'middleware' do
     describe 'client' do
       it 'should not debounce anything via perform_async' do
-        expect(SidekiqFastDebounce::Utils).to_not receive(:debounce_opts)
+        expect(SidekiqFastDebounce::Utils).to_not receive(:debounce_key)
 
         SfdWorker.perform_async('abc123')
       end
 
       it 'should debounce via perform_debounce' do
-        expect(SidekiqFastDebounce::Utils).to receive(:debounce_opts).and_return({})
+        expect(SidekiqFastDebounce::Utils).to receive(:debounce_key).and_return('asdf')
 
         SfdWorker.perform_debounce(3, 'abc123')
       end
@@ -36,51 +36,67 @@ RSpec.describe Middleware::Sidekiq::Client::FastDebounce do
         end
       end
 
-      it 'should use debounce_key override passed into perform_debounce' do
-        # not present yet
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::SfdWorker::stuff')).to eq(nil)
+      describe 'option overrides' do
+        it 'should use debounce_key override' do
+          # not present yet
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::SfdWorker::stuff')).to eq(nil)
+          end
+
+          # set it to this job id
+          jid1 = SfdWorker.set(debounce_key: 'stuff').perform_debounce(3, 'abc123')
+
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::SfdWorker::stuff')).to eq(jid1)
+          end
+
+          # update key to new job id
+          jid2 = SfdWorker.set(debounce_key: 'stuff').perform_debounce(3, 'abc123')
+
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::SfdWorker::stuff')).to eq(jid2)
+          end
         end
 
-        # set it to this job id
-        jid1 = SfdWorker.perform_debounce(3, 'abc123', debounce_key: 'stuff')
+        it 'should use debounce_namespace override' do
+          # not present yet
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::stuff::abc123')).to eq(nil)
+          end
 
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::SfdWorker::stuff')).to eq(jid1)
+          # set it to this job id
+          jid1 = SfdWorker.set(debounce_namespace: 'stuff').perform_debounce(3, 'abc123')
+
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::stuff::abc123')).to eq(jid1)
+          end
+
+          # update key to new job id
+          jid2 = SfdWorker.set(debounce_namespace: 'stuff').perform_debounce(3, 'abc123')
+
+          ::Sidekiq.redis do |conn|
+            expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
+            expect(conn.get('debounce::stuff::abc123')).to eq(jid2)
+          end
         end
 
-        # update key to new job id
-        jid2 = SfdWorker.perform_debounce(3, 'abc123', debounce_key: 'stuff')
+        it 'should use debounce_ttl override' do
+          SfdWorker.perform_debounce(3, 'abc123')
 
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::SfdWorker::stuff')).to eq(jid2)
-        end
-      end
+          ::Sidekiq.redis do |conn|
+            expect(conn.ttl('debounce::SfdWorker::abc123')).to be_within(1).of(63)
+          end
 
-      it 'should use debounce_namespace override passed into perform_debounce' do
-        # not present yet
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::stuff::abc123')).to eq(nil)
-        end
+          SfdWorker.set(debounce_ttl: 30).perform_debounce(3, 'abc1234')
 
-        # set it to this job id
-        jid1 = SfdWorker.perform_debounce(3, 'abc123', debounce_namespace: 'stuff')
-
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::stuff::abc123')).to eq(jid1)
-        end
-
-        # update key to new job id
-        jid2 = SfdWorker.perform_debounce(3, 'abc123', debounce_namespace: 'stuff')
-
-        ::Sidekiq.redis do |conn|
-          expect(conn.get('debounce::SfdWorker::abc123')).to eq(nil)
-          expect(conn.get('debounce::stuff::abc123')).to eq(jid2)
+          ::Sidekiq.redis do |conn|
+            expect(conn.ttl('debounce::SfdWorker::abc1234')).to be_within(1).of(33)
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,6 @@ end
 
 class SfdWorker
   include Sidekiq::Worker
-  include SidekiqFastDebounce
 
   def self.trigger(arg1); end
 
@@ -31,7 +30,6 @@ end
 
 class SfdWorker2
   include Sidekiq::Worker
-  include SidekiqFastDebounce
 
   def self.trigger(arg1, arg2); end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,16 @@ class SfdWorker2
   end
 end
 
+class SfdWorker3
+  include Sidekiq::Worker
+
+  def self.trigger(arg1); end
+
+  def perform(arg1)
+    self.class.trigger(arg1)
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -6,136 +6,24 @@ class NamespaceWorker; end
 class KeyWorker; end
 
 RSpec.describe SidekiqFastDebounce::Utils do
-  describe 'extract_opt!' do
-    it 'returns present: false' do
-      args = {
-        things: 1234
-      }
-
-      opt = SidekiqFastDebounce::Utils.extract_opt!(:test, args)
-
-      expect(opt.size).to eq(0)
-      expect(opt.key?(:value)).to eq(false)
-
-      expect(args.size).to eq(1)
-      expect(args[:things]).to eq(1234)
-    end
-
-    it 'finds symbol' do
-      args = {
-        things: 1234,
-        stuff: :junk
-      }
-
-      opt = SidekiqFastDebounce::Utils.extract_opt!(:things, args)
-
-      expect(opt.size).to eq(1)
-      expect(opt[:value]).to eq(1234)
-
-      expect(args.size).to eq(1)
-      expect(args[:stuff]).to eq(:junk)
-      expect(args.key?(:things)).to eq(false)
-    end
-
-    it 'finds string' do
-      args = {
-        'things' => 1234,
-        :stuff => :junk
-      }
-
-      opt = SidekiqFastDebounce::Utils.extract_opt!(:things, args)
-
-      expect(opt.size).to eq(1)
-      expect(opt[:value]).to eq(1234)
-
-      expect(args.size).to eq(1)
-      expect(args[:stuff]).to eq(:junk)
-      expect(args.key?(:things)).to eq(false)
-    end
-  end
-
-  describe 'debounce_opts' do
-    it 'finds no override opts' do
-      job = sidekiq_job('KeyWorker', [1, 'arg'])
-      opts = SidekiqFastDebounce::Utils.debounce_opts(job)
-
-      expect(opts.size).to eq(0)
-      expect(job['args'].length).to eq(2)
-      expect(job['args']).to eq([1, 'arg'])
-    end
-
-    it 'find debounce_key option' do
-      job = sidekiq_job('KeyWorker', [1, 'arg', { 'debounce_key' => 'abc123' }])
-      opts = SidekiqFastDebounce::Utils.debounce_opts(job)
-
-      expect(opts.size).to eq(1)
-      expect(opts[:debounce_key]).to eq('abc123')
-
-      expect(job['args'].length).to eq(2)
-      expect(job['args']).to eq([1, 'arg'])
-    end
-
-    it 'find debounce_namespace option' do
-      job = sidekiq_job('KeyWorker', [1, 'arg', { 'debounce_namespace' => 'abc123' }])
-      opts = SidekiqFastDebounce::Utils.debounce_opts(job)
-
-      expect(opts.size).to eq(1)
-      expect(opts[:debounce_namespace]).to eq('abc123')
-
-      expect(job['args'].length).to eq(2)
-      expect(job['args']).to eq([1, 'arg'])
-    end
-
-    it 'find debounce_key option - leave other arg alone' do
-      job = sidekiq_job('KeyWorker', [1, 'arg', { 'stuff' => 'junk', 'debounce_key' => 'abc123' }])
-      opts = SidekiqFastDebounce::Utils.debounce_opts(job)
-
-      expect(opts.size).to eq(1)
-      expect(opts[:debounce_key]).to eq('abc123')
-
-      expect(job['args'].length).to eq(3)
-      expect(job['args']).to eq([1, 'arg', { 'stuff' => 'junk' }])
-    end
-  end
-
-  describe 'debounce_namespace' do
-    it 'should return the class name' do
-      namespace = SidekiqFastDebounce::Utils.debounce_namespace(NamespaceWorker, {})
-      expect(namespace).to eq('NamespaceWorker')
-    end
-
-    it 'should return the namespace override' do
-      deb_opts = { debounce_namespace: 'test' }
-      namespace = SidekiqFastDebounce::Utils.debounce_namespace(NamespaceWorker, {}, deb_opts)
-      expect(namespace).to eq('test')
-    end
-  end
-
   describe 'debounce_key' do
     it 'should raise error' do
       job = sidekiq_job('KeyWorker', [])
       expect do
-        SidekiqFastDebounce::Utils.debounce_key(KeyWorker, job)
+        SidekiqFastDebounce::Utils.debounce_key(job)
       end.to raise_exception(ArgumentError)
     end
 
     it 'should return the only argument' do
       job = sidekiq_job('KeyWorker', [1])
-      deb_key = SidekiqFastDebounce::Utils.debounce_key(KeyWorker, job)
+      deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
       expect(deb_key).to eq(1)
     end
 
     it 'should return the MD5 hash of the arguments' do
       job = sidekiq_job('KeyWorker', [1, 'arg'])
-      deb_key = SidekiqFastDebounce::Utils.debounce_key(KeyWorker, job)
+      deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
       expect(deb_key).to eq('415320f7fea0e4bfc905250606eeb3f5')
-    end
-
-    it 'should return the debounce_key override' do
-      deb_opts = { debounce_key: 'test' }
-      sidekiq_job('KeyWorker', [1, 'arg'])
-      deb_key = SidekiqFastDebounce::Utils.debounce_key(KeyWorker, {}, deb_opts)
-      expect(deb_key).to eq('test')
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -2,28 +2,66 @@
 
 require 'spec_helper'
 
-class NamespaceWorker; end
-class KeyWorker; end
+class MyWorker; end
 
 RSpec.describe SidekiqFastDebounce::Utils do
-  describe 'debounce_key' do
-    it 'should raise error' do
-      job = sidekiq_job('KeyWorker', [])
-      expect do
-        SidekiqFastDebounce::Utils.debounce_key(job)
-      end.to raise_exception(ArgumentError)
+  describe 'base_key' do
+    it 'no args' do
+      job = sidekiq_job('MyWorker', [])
+      base_key = SidekiqFastDebounce::Utils.base_key(job)
+      expect(base_key).to eq('DEBOUNCE_NO_ARGS')
     end
 
     it 'should return the only argument' do
-      job = sidekiq_job('KeyWorker', [1])
-      deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
-      expect(deb_key).to eq(1)
+      job = sidekiq_job('MyWorker', [1])
+      base_key = SidekiqFastDebounce::Utils.base_key(job)
+      expect(base_key).to eq(1)
     end
 
     it 'should return the MD5 hash of the arguments' do
-      job = sidekiq_job('KeyWorker', [1, 'arg'])
+      job = sidekiq_job('MyWorker', [1, 'arg'])
+      base_key = SidekiqFastDebounce::Utils.base_key(job)
+      expect(base_key).to eq('415320f7fea0e4bfc905250606eeb3f5')
+    end
+
+    context 'debounce_key override' do
+      it 'string' do
+        job = sidekiq_job('MyWorker', [])
+        job['debounce_key'] = 'my_key'
+        base_key = SidekiqFastDebounce::Utils.base_key(job)
+        expect(base_key).to eq('my_key')
+      end
+
+      it 'symbol' do
+        job = sidekiq_job('MyWorker', [1])
+        job[:debounce_key] = 'my_key'
+        base_key = SidekiqFastDebounce::Utils.base_key(job)
+        expect(base_key).to eq('my_key')
+      end
+    end
+  end
+
+  describe 'debounce_key' do
+    it 'base case' do
+      job = sidekiq_job('MyWorker', [1])
       deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
-      expect(deb_key).to eq('415320f7fea0e4bfc905250606eeb3f5')
+      expect(deb_key).to eq('debounce::MyWorker::1')
+    end
+
+    context 'debounce_namespace override' do
+      it 'string' do
+        job = sidekiq_job('MyWorker', ['asdf'])
+        job['debounce_namespace'] = 'my_name'
+        deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
+        expect(deb_key).to eq('debounce::my_name::asdf')
+      end
+
+      it 'string' do
+        job = sidekiq_job('MyWorker', [1])
+        job[:debounce_namespace] = 'my_name'
+        deb_key = SidekiqFastDebounce::Utils.debounce_key(job)
+        expect(deb_key).to eq('debounce::my_name::1')
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of passing them in as optional params to `perform_debounce`, be more explicit and use `set` to override any of the options.